### PR TITLE
Modify timing card name for all test classes for ATS hardware

### DIFF
--- a/Source/Tests/System/Common System Tests/Assets/config.ini
+++ b/Source/Tests/System/Common System Tests/Assets/config.ini
@@ -1,3 +1,3 @@
 [Overrides]
 "Targets/Controller/IP Address" = "VS-Eco-Slave-8880"
-"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "Dev1"
+"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "PXI1Slot5"

--- a/Source/Tests/System/Linux x64 System Tests/Assets/config.ini
+++ b/Source/Tests/System/Linux x64 System Tests/Assets/config.ini
@@ -1,3 +1,3 @@
 [Overrides]
 "Targets/Controller/IP Address" = "VS-Eco-Slave-8880"
-"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "Dev1"
+"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "PXI1Slot5"

--- a/Source/Tests/System/PharLap System Tests/Assets/config.ini
+++ b/Source/Tests/System/PharLap System Tests/Assets/config.ini
@@ -1,3 +1,3 @@
 [Overrides]
 "Targets/Controller/IP Address" = "VS-Eco-Slave-8880"
-"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "Dev1"
+"Targets/Controller/Hardware/Chassis/Timing and Sync/NI Synchronization/user.CD.TimeKeeper" = "PXI1Slot5"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-chassis-timesync-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The Linux target in the ATS cannot persist renaming the PXI-6683H. To workaround this, the Pharlap name is now the same as the Linux name (PXI1Slot5). This PR modifies the test config files to always use PXI1Slot5 for all system tests.

### Why should this Pull Request be merged?

Pass ATS tests on both Linux and Pharlap.

### What testing has been done?

Ran tests locally on the ATS.
