### PR TITLE
Add VeriStand as an nipkg dependency

### DIFF
--- a/control
+++ b/control
@@ -13,3 +13,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Synchronization Custom Device for VeriStand {veristand_version}
+Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-chassis-timesync-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the corresponding VeriStand version as an nipkg dependency.

### Why should this Pull Request be merged?

This prevents installing the custom device without the corresponding version of VeriStand being installed.

### What testing has been done?

Tested that I can't install the custom device without VeriStand being installed, and that removing VeriStand removes the custom device package.


### Open questions:

- [ ] Should the custom device also _supplement_ VeriStand, in addition to depending on it?