### PR TITLE
Mark architecture as windows_x64

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ni-synchronization-veristand-{veristand_version}-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides support for the NI Synchronization Custom Device for NI VeriStand {veristand_version}.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-synchronization-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change package architecture to windows_x64, to align with the VeriStand 2019 and newer package architecture.

### Why should this Pull Request be merged?

VeriStand 2019 and newer are windows_x64 packages, so having the custom device be windows_all is a bit nonsensical (and is causing warnings to be thrown by internal tooling). Changing the package to windows_x64 prevents installation of the custom devices via .nipkg on 32-bit Windows for VeriStand 2018 and older, but this is a niche use case and workarounds are available.

### What testing has been done?

None.
