### PR TITLE
Parent custom device under NI in menu

### DIFF
--- a/Source/Timing and Sync - NI Synchronization.xml
+++ b/Source/Timing and Sync - NI Synchronization.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>National Instruments::Synchronization</eng>
-    <loc>National Instruments::Synchronization</loc>
+    <eng>NI::Synchronization</eng>
+    <loc>NI::Synchronization</loc>
   </AddMenu>
   <Version>2.0.0</Version>
   <Type>Asynchronous Timing and Sync</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-synchronization-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the custom device appear under the "NI" menu item, rather than "National Instruments".

### Why should this Pull Request be merged?

Branding update.

### What testing has been done?

N/A
