### PR TITLE
Update azure-pipelines.yml to bump to 26.5.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
           target: 'All'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '26.0.0'
+      releaseVersion: '26.5.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\ni_synchronization_custom_device'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-synchronization-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-synchronization-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version to 26.5.0

### Why should this Pull Request be merged?

Necessary for 26.5 release

### What testing has been done?

None
